### PR TITLE
DM-13145: Fix title truncation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,7 +15,7 @@ from . import dashboard  # noqa: F401
 
 
 # Application version; should match Git tags and docker tags
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 def create_app(profile='production'):

--- a/app/dashboard/render.py
+++ b/app/dashboard/render.py
@@ -14,7 +14,7 @@ from .jinjafilters import filter_simple_date
 TICKET_BRANCH_PATTERN = re.compile('^tickets/([A-Z]+-[0-9]+)')
 
 # regular expression that matches a document handle as a slug
-DOC_HANDLE_PATTERN = re.compile('^(sqr|dmtn|smtn|ldm|lse|lpm)-[0-9]+$')
+DOC_HANDLE_PATTERN = re.compile('^(sqr|dmtn|smtn|ldm|lse|lpm|dmtr)-[0-9]+$')
 
 # regular expression that matches version strings
 RELEASE_PATTERN = re.compile('^v\d+')
@@ -27,6 +27,7 @@ SERIES_NAMES = {
     'ldm': 'LSST Data Management',
     'lse': 'LSST Systems Engineering',
     'lpm': 'LSST Project Management',
+    'dmtr': 'Data Management Test Report',
 }
 
 

--- a/app/dashboard/render.py
+++ b/app/dashboard/render.py
@@ -19,9 +19,6 @@ DOC_HANDLE_PATTERN = re.compile('^(sqr|dmtn|smtn|ldm|lse|lpm)-[0-9]+$')
 # regular expression that matches version strings
 RELEASE_PATTERN = re.compile('^v\d+')
 
-# regular expression for extracting a handle-less title from a title string
-TITLE_PATTERN = re.compile('^((?:SQR|DMTN|SMTN|LDM|LSE|LPM)-[0-9]+)(?::)?(?:\s)?(.+)$')  # noqa: E501
-
 # map of series handles to descriptive names
 SERIES_NAMES = {
     'sqr': 'SQuaRE Technical Note',
@@ -238,10 +235,10 @@ def _insert_doc_handle(product, handle_key='doc_handle',
 
 def _normalize_product_title(product):
     """Remove the handle prefix from a product title, if present."""
-    # remove the handle and any ": " from the title
-    m = TITLE_PATTERN.match(product['title'])
-    if m is not None:
-        product['title'] = m.group(2)
+    if 'doc_handle' in product:
+        if product['title'].startswith(product['doc_handle']):
+            product['title'] = product['title'][len(product['doc_handle']):]
+    product['title'] = product['title'].strip(': ')
 
 
 def _insert_is_release(editions,

--- a/kubernetes/dasher-deployment.yaml
+++ b/kubernetes/dasher-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       containers:
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-dasher:v0.1.1"
+          image: "lsstsqre/ltd-dasher:0.1.2"
           ports:
             - containerPort: 3031
               name: dasher

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -25,10 +25,13 @@ def test_doc_handle(slug, expected_handle, expected_series_name):
       'Starts with an S'),
      ('SQR-000 Starts with an S',
       'Starts with an S'),
+     ('SQR-001 Starts with an S',
+      'SQR-001 Starts with an S'),
      ('Starts with an S',
       'Starts with an S')])
 def test_product_title(title, expected_title):
     product = {
+        'doc_handle': 'SQR-000',
         'title': title
     }
 


### PR DESCRIPTION
Only the document's own handle is truncated from a title. This fixes an issue with test reports where the DMTR's title legitimately includes the handle of the base test specification document. For example:

> LDM-503-3 (Alert Generation) Test Report

Also, adds support for DMTR handles.