### PR TITLE
DM-15075: Fix for editions that do not have a tracked_refs field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,10 @@
+##########
+Change log
+##########
+
+0.1.3 (2018-07-11)
+==================
+
+- Fixed a bug when an LTD Keeper Edition had a ``tracked_refs`` field with a value of ``None`` (because the Edition does not use the ``git_refs`` tracking mode`).
+  First, the GitHub link does not appear if ``tracked_refs`` is not available.
+  Second, version heuristics are now computed against the ``slug``.

--- a/app/dashboard/render.py
+++ b/app/dashboard/render.py
@@ -168,7 +168,14 @@ def _insert_github_ref_url(product, edition_dataset,
     """
     base_repo_url = product['doc_repo'].rstrip('.git')
     for k, d in edition_dataset.items():
-        git_ref = d[git_refs_key][0]
+        # Editions that don't use the git_refs tracking mode will have
+        # tracked_refs equal to None.
+        try:
+            git_ref = d[git_refs_key][0]
+        except TypeError:
+            # None is not indexable
+            continue
+
         # https://github.com/lsst-sqre/ltd-dasher/tree/tickets/DM-9023
         url = base_repo_url + '/tree/' + git_ref
         d[key] = url
@@ -182,7 +189,14 @@ def _insert_jira_url(edition_dataset, git_refs_key='tracked_refs',
     re-thought for multi-repo LTD products.
     """
     for k, d in edition_dataset.items():
-        git_ref = d[git_refs_key][0]
+        # Editions that don't use the git_refs tracking mode will have
+        # tracked_refs equal to None.
+        try:
+            git_ref = d[git_refs_key][0]
+        except TypeError:
+            # None is not indexable
+            continue
+
         match = TICKET_BRANCH_PATTERN.search(git_ref)
         if match is not None:
             ticket_name = match.group(1)
@@ -251,11 +265,11 @@ def _insert_is_release(editions,
     Heuristic for guessing a release: edition slug begins with `v` and a digit.
     """
     for k, d in editions.items():
-        git_ref = d['tracked_refs'][0]
-        match = RELEASE_PATTERN.search(git_ref)
+        slug = d['slug']
+        match = RELEASE_PATTERN.search(slug)
         if match is not None:
             d[is_release_key] = True
-            d[alt_title_key] = git_ref
+            d[alt_title_key] = slug
         else:
             d[is_release_key] = False
 

--- a/app/dashboard/templates/_edition_item.jinja
+++ b/app/dashboard/templates/_edition_item.jinja
@@ -28,10 +28,12 @@
         <span><span class="svg-icon svg-icon--left svg-icon--jira svg-baseline"><svg><use xlink:href="#icon-jira-blue" /></svg></span> <a href="{{ item.jira_url }}">{{ item.jira_ticket_name }}</a></span>
       </div>
     {% endif %}
+    {% if item.github_ref_url %}
     <div class="inventory-item-metadata__github-branch-box">
       {# FIXME could have an edition with multiple branches (multi-repo products)
       For the MVP I'm ignoring this. #}
       <span><span class="svg-icon svg-icon--left svg-baseline"><svg><use xlink:href="#octicon-mark-github" /></svg></span><a href="{{ item.github_ref_url }}">View source</a></span>
     </div>
+    {% endif %}
   </div>
 </article>

--- a/kubernetes/dasher-deployment.yaml
+++ b/kubernetes/dasher-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dasher-deployment
 
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -13,7 +13,7 @@ spec:
       containers:
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-dasher:0.1.2"
+          image: "lsstsqre/ltd-dasher:0.1.3"
           ports:
             - containerPort: 3031
               name: dasher


### PR DESCRIPTION
Fixed a bug when an LTD Keeper Edition had a ``tracked_refs`` field with a value of ``None`` (because the Edition does not use the ``git_refs`` tracking mode`).
 
First, the GitHub link does not appear if ``tracked_refs`` is not available.

Second, version heuristics are now computed against the ``slug``.

Fixes #6