### PR TITLE
DM-27805: Fix gulp environment in GitHub workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: npm install .
 
       - name: Create assets
-        run: gulp assets -env=deploy
+        run: gulp assets --env=deploy
 
       - name: Build the runtime Docker image
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ##########
 
+0.1.10 (2020-12-02)
+===================
+
+- Fix gulp build configuration for Docker image.
+
 0.1.9 (2020-12-01)
 ==================
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,7 +15,7 @@ from . import dashboard  # noqa: F401
 
 
 # Application version; should match Git tags and docker tags
-__version__ = '0.1.9'
+__version__ = '0.1.10'
 
 
 def create_app(profile='production'):

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: lsstsqre/ltd-dasher
-    newTag: 0.1.9
+    newTag: 0.1.10
 
 resources:
   - dasher-deployment.yaml


### PR DESCRIPTION
Before the `--env` flag was not being set to "deploy", so the assets weren't being built in the correct location.